### PR TITLE
Move printing of messages to the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 There are many idioms in nixpkgs which beginner packagers might not be aware of. This is a set of nit-picky rules that aim to point out and explain common mistakes in nixpkgs package pull requests.
 
-This repository contains a bunch of [overlays](https://nixos.org/nixpkgs/manual/#chap-overlays) that add extra checks to `stdenv.mkDerivation` and other similar nixpkgs tools. The `nixpkgs-hammer` command will try to build the specified attributes with the overlays, making sure the warnings only touch the attributes you care about, not their dependencies.
+This repository contains a bunch of [overlays](https://nixos.org/nixpkgs/manual/#chap-overlays) that add extra checks to `stdenv.mkDerivation` and other similar nixpkgs tools. The `nixpkgs-hammer` command will try to evaluate the specified attributes with the overlays, making sure the warnings only touch the attributes you care about, not their dependencies.
 
 *Note that while these rules almost always apply, there are some exceptions. Please read the explanations before taking an action.*
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,34 +14,6 @@ rec {
       in
         lib.toUpper head + tail;
 
-  replicate = n: x: builtins.concatStringsSep "" (builtins.genList (_: x) n);
-
-  printLocation = { file, line, column }:
-    let
-      allLines = lib.splitString "\n" (builtins.readFile file);
-      lineContents = builtins.elemAt allLines (line - 1);
-      lineSpaces = replicate (builtins.stringLength (builtins.toString line)) " ";
-      pointer = replicate (column - 1) " " + "^";
-    in
-      file + ":" + builtins.toString line + ":" + builtins.toString column + ":\n" +
-      lineSpaces + " |\n" +
-      builtins.toString line + " | " + lineContents + "\n" +
-      lineSpaces + " | " + pointer + "\n";
-
-  printError = { name, msg, locations ? [], ... }:
-    msg +
-    lib.concatMapStringsSep "\n" printLocation locations +
-    "See: https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/${name}.md";
-
-  warn = warnings:
-    let
-      matchedWarnings = lib.filter ({ cond, ... }: cond) warnings;
-    in
-      if builtins.length matchedWarnings > 0 then
-        lib.warn (lib.concatMapStringsSep "\n" printError matchedWarnings)
-      else
-        lib.id;
-
   # Creates an overlay that replaces stdenv.mkDerivation with a function that,
   # for packages with locations of name attribute matching one of the namePositions,
   # checks the attribute set passed as argument to mkDerivation.
@@ -68,8 +40,11 @@ rec {
           in
             if builtins.elem namePosition namePositions
             then
-              warn (check drv)
-              originalDrv
+              lib.recursiveUpdate originalDrv {
+                __nixpkgs-hammering-state = {
+                  reports = originalDrv.__nixpkgs-hammering-state.reports or [] ++ lib.filter ({ cond, ... }: cond) (check drv);
+                };
+              }
             else
               originalDrv;
       };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,5 @@
-{ pkgs ? (import ../default.nix).inputs.nixpkgs.legacyPackages.${builtins.currentSystem}
+{ overlays ? []
+, pkgs ? import (import ../default.nix).inputs.nixpkgs.outPath { inherit overlays; }
 }:
 
 {

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -2,8 +2,9 @@
 
 from pathlib import Path
 import argparse
+import json
 import subprocess
-import tempfile
+import sys
 
 
 def escape_nix_string(val: str) -> str:
@@ -15,6 +16,55 @@ def nix_eval(expr: str) -> str:
         ['nix-instantiate', '--eval', '-E', expr],
         encoding='utf-8',
     )
+
+
+def nix_eval_json(expr: str):
+    result = subprocess.check_output(
+        ['nix-instantiate', '--strict', '--json', '--eval', '-E', expr],
+        encoding='utf-8',
+    )
+    return json.loads(result)
+
+
+def yellow(msg):
+    return f'[1;33m{msg}[0m'
+
+
+def red(msg):
+    return f'[1;31m{msg}[0m'
+
+
+def stringify_location(file, line, column):
+    with open(file, 'r') as opened_file:
+        all_lines = opened_file.read().splitlines()
+        line_contents = all_lines[line - 1]
+        line_spaces = ' ' * len(str(line))
+        pointer = ' ' * (column - 1) + '^'
+
+        location_lines = [
+            'Near ' + file + ':' + str(line) + ':' + str(column) + ':',
+            line_spaces + ' |',
+            str(line) + ' | ' + line_contents,
+            line_spaces + ' | ' + pointer,
+        ]
+
+    return '\n'.join(location_lines)
+
+
+def stringify_message(name, msg, locations=[], cond=True, link=True, severity='warning'):
+    color = red if severity == 'error' else yellow
+
+    message_lines = [
+        color(f'{severity}: {name}'),
+        msg,
+    ] + list(map(lambda loc: stringify_location(**loc), locations))
+
+    if link:
+        message_lines.append(
+            f'See: https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/{name}.md',
+        )
+
+    return '\n'.join(message_lines)
 
 
 def main(args):
@@ -29,17 +79,30 @@ def main(args):
         build_args.append('--show-trace')
 
     attrs_nix = []
+    attr_messages = []
     name_positions = []
 
     for attr in args.attr_paths:
-        build_args.extend(['-A', attr])
-
         attrs_nix.append(escape_nix_string(attr))
+
+        attr_messages.append(
+            f'''
+            (if pkgs.{attr} or null == null then
+                [ {{
+                    name = "AttrPathNotFound";
+                    msg = "Packages in ‘{args.nix_file}’ do not contain ‘{attr}’ attribute.";
+                    severity = "error";
+                    link = false;
+                }} ]
+            else
+                pkgs.{attr}.__nixpkgs-hammering-state.reports or [])
+            '''
+        )
 
         name_position = nix_eval(
             f'''
             let
-                drv = (import {args.nix_file} {{}}).{attr};
+                drv = (import {args.nix_file} {{ }}).{attr};
                 pname = builtins.unsafeGetAttrPos "pname" drv;
             in
                 if pname != null then
@@ -50,28 +113,35 @@ def main(args):
         )
         name_positions.append('(' + name_position + ')')
 
-    build_args.append('--no-out-link')
-
     # Our overlays need to know the built attributes so that they can check only them.
     # We do it by using functions that return overlays so we need to instantiate them.
-    with tempfile.TemporaryDirectory() as saturated_overlays_tempdir:
-        saturated_overlays_path = Path(saturated_overlays_tempdir)
-        for overlay_generator in overlay_generators_path.glob('*'):
-            overlay = overlay_generator.name
-            with open(saturated_overlays_path / overlay, 'w') as generated_overlay:
-                generated_overlay.write(
-                    f'''
-                    import {overlay_generators_path}/{overlay} {{
-                        builtAttrs = [ {" ".join(attrs_nix)} ];
-                        packageSet = {args.nix_file};
-                        namePositions = [ {" ".join(name_positions)} ];
-                    }}
-                    '''
-                )
+    overlay_expressions = []
+    for overlay_generator in overlay_generators_path.glob('*'):
+        overlay = overlay_generator.name
+        overlay_expressions.append(
+            f'''
+            (import {overlay_generators_path}/{overlay} {{
+                builtAttrs = [ {" ".join(attrs_nix)} ];
+                packageSet = {args.nix_file};
+                namePositions = [ {" ".join(name_positions)} ];
+            }})
+            '''
+        )
 
-        build_args.extend(['-I', f'nixpkgs-overlays={saturated_overlays_path}'])
+    messages = nix_eval_json(
+        f'''
+        let
+            pkgs = import {args.nix_file} {{
+                overlays = [
+                    {" ".join(overlay_expressions)}
+                ];
+            }};
+        in
+            builtins.concatLists [ {" ".join(attr_messages)} ]
+        ''',
+    )
 
-        subprocess.run(['nix-build'] + build_args, check=True)
+    print('\n'.join(map(lambda msg: stringify_message(**msg), messages)), file=sys.stderr)
 
 
 if __name__ == '__main__':
@@ -83,11 +153,11 @@ if __name__ == '__main__':
         '--file',
         dest='nix_file',
         metavar='FILE',
-        # Absolutize so we can refer to it from tempdir.
+        # Absolutize so we can refer to it from Nix.
         type=lambda p: Path(p).resolve(strict=True),
         # Nix defaults to current directory when file not specified.
         default=Path.cwd(),
-        help='evaluate FILE rather than the default',
+        help='evaluate attributes in given path rather than the default (current working directory). The path needs to be importable by Nix and the imported value has to accept attribute set with overlays attribute as an argument.',
     )
     parser.add_argument(
         '--show-trace',

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -117,6 +117,9 @@ def main(args):
     # We do it by using functions that return overlays so we need to instantiate them.
     overlay_expressions = []
     for overlay_generator in overlay_generators_path.glob('*'):
+        if overlay_generator.stem in args.excluded_rules:
+            continue
+
         overlay = overlay_generator.name
         overlay_expressions.append(
             f'''
@@ -164,6 +167,15 @@ if __name__ == '__main__':
         dest='show_trace',
         action='store_true',
         help='show trace when error occurs',
+    )
+    parser.add_argument(
+        '-e',
+        '--exclude',
+        metavar='rule',
+        dest='excluded_rules',
+        action='append',
+        default=[],
+        help='rule to exclude',
     )
     parser.add_argument(
         'attr_paths',

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -26,12 +26,20 @@ def nix_eval_json(expr: str):
     return json.loads(result)
 
 
+def bold(msg):
+    return f'[1m{msg}[0m'
+
+
 def yellow(msg):
     return f'[1;33m{msg}[0m'
 
 
 def red(msg):
     return f'[1;31m{msg}[0m'
+
+
+def green(msg):
+    return f'[1;32m{msg}[0m'
 
 
 def stringify_location(file, line, column):
@@ -87,7 +95,7 @@ def main(args):
 
         attr_messages.append(
             f'''
-            (if pkgs.{attr} or null == null then
+            "{attr}" = if pkgs.{attr} or null == null then
                 [ {{
                     name = "AttrPathNotFound";
                     msg = "Packages in ‘{args.nix_file}’ do not contain ‘{attr}’ attribute.";
@@ -95,7 +103,7 @@ def main(args):
                     link = false;
                 }} ]
             else
-                pkgs.{attr}.__nixpkgs-hammering-state.reports or [])
+                pkgs.{attr}.__nixpkgs-hammering-state.reports or [];
             '''
         )
 
@@ -131,7 +139,7 @@ def main(args):
             '''
         )
 
-    messages = nix_eval_json(
+    all_messages = nix_eval_json(
         f'''
         let
             pkgs = import {args.nix_file} {{
@@ -140,11 +148,17 @@ def main(args):
                 ];
             }};
         in
-            builtins.concatLists [ {" ".join(attr_messages)} ]
+            {{ {" ".join(attr_messages)} }}
         ''',
     )
 
-    print('\n'.join(map(lambda msg: stringify_message(**msg), messages)), file=sys.stderr)
+    for attr, messages in all_messages.items():
+        print(bold(f'When evaluating attribute ‘{attr}’:'), file=sys.stderr)
+        if len(messages) > 0:
+            print('\n'.join(map(lambda msg: stringify_message(**msg), messages)), file=sys.stderr)
+        else:
+            print(green('No issues found.'), file=sys.stderr)
+        print(file=sys.stderr)
 
 
 if __name__ == '__main__':
@@ -175,7 +189,7 @@ if __name__ == '__main__':
         dest='excluded_rules',
         action='append',
         default=[],
-        help='rule to exclude',
+        help='rule to exclude (can be passed repeatedly)',
     )
     parser.add_argument(
         'attr_paths',

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -1,110 +1,107 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-set -e
+from pathlib import Path
+import argparse
+import subprocess
+import tempfile
 
-scriptName=nixpkgs-hammer # do not use the .wrapped name
-scriptDir=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
-overlaysPath="${scriptDir}/../overlays"
 
-usage() {
-    echo "Usage: $scriptName [<flags>...] <attr-paths>..."
-    echo
-    echo "Summary: check package expressions for common mistakes"
-    echo
-    echo "Flags:"
-    echo "    -f, --file <FILE>     evaluate FILE rather than the default"
-    echo "    --show-trace          show trace when error occurs"
-}
+def escape_nix_string(val: str) -> str:
+    return '"' + val.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
-die() {
-    echo "$scriptName: error: $1" >&2
-    exit 1
-}
 
-die_with_usage() {
-    echo "$scriptName: error: $1" >&2
-    usage
-    exit 1
-}
+def nix_eval(expr: str) -> str:
+    return subprocess.check_output(
+        ['nix-instantiate', '--eval', '-E', expr],
+        encoding='utf-8',
+    )
 
-escapeNixString() {
-    val=$1
-    val="${val//\\/\\\\}"
-    val="${val//\"/\\\"}"
-    echo "\"${val}\""
-}
 
-nixFile=
-attrPaths=()
-buildArgs=()
+def main(args):
+    script_dir = Path(__file__).parent
+    overlay_generators_path = (script_dir.parent / 'overlays').absolute()
 
-while [ "$#" -gt 0 ]; do
-    arg="$1"; shift 1
-    case "$arg" in
-      --help)
-        usage
-        exit 0
-        ;;
-      --file=*)
-        nixFile="${arg#*=}"
-        ;;
-      --file|-f)
-        nixFile="$1"
-        shift 1
-        ;;
-      --show-trace)
-        buildArgs+=("$arg")
-        ;;
-      -*)
-        die "unknown option ‘${arg}’."
-        ;;
-      *)
-        attrPaths+=("$arg")
-        ;;
-    esac
-done
+    build_args = [
+        args.nix_file,
+    ]
 
-if (( "${#attrPaths[*]}" == 0 )); then
-    die_with_usage "Too few attr-paths."
-fi
+    if args.show_trace:
+        build_args.append('--show-trace')
 
-if [[ -n "$nixFile" ]]; then
-    if [[ -e "$nixFile" ]]; then
+    attrs_nix = []
+    name_positions = []
+
+    for attr in args.attr_paths:
+        build_args.extend(['-A', attr])
+
+        attrs_nix.append(escape_nix_string(attr))
+
+        name_position = nix_eval(
+            f'''
+            let
+                drv = (import {args.nix_file} {{}}).{attr};
+                pname = builtins.unsafeGetAttrPos "pname" drv;
+            in
+                if pname != null then
+                    pname
+                else
+                    builtins.unsafeGetAttrPos "name" drv
+            '''
+        )
+        name_positions.append('(' + name_position + ')')
+
+    build_args.append('--no-out-link')
+
+    # Our overlays need to know the built attributes so that they can check only them.
+    # We do it by using functions that return overlays so we need to instantiate them.
+    with tempfile.TemporaryDirectory() as saturated_overlays_tempdir:
+        saturated_overlays_path = Path(saturated_overlays_tempdir)
+        for overlay_generator in overlay_generators_path.glob('*'):
+            overlay = overlay_generator.name
+            with open(saturated_overlays_path / overlay, 'w') as generated_overlay:
+                generated_overlay.write(
+                    f'''
+                    import {overlay_generators_path}/{overlay} {{
+                        builtAttrs = [ {" ".join(attrs_nix)} ];
+                        packageSet = {args.nix_file};
+                        namePositions = [ {" ".join(name_positions)} ];
+                    }}
+                    '''
+                )
+
+        build_args.extend(['-I', f'nixpkgs-overlays={saturated_overlays_path}'])
+
+        subprocess.run(['nix-build'] + build_args, check=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='check package expressions for common mistakes',
+    )
+    parser.add_argument(
+        '-f',
+        '--file',
+        dest='nix_file',
+        metavar='FILE',
         # Absolutize so we can refer to it from tempdir.
-        nixFile=$(readlink -f "$nixFile")
-    fi
-    buildArgs+=("$nixFile")
-else
-    # Nix defaults to current directory when file not specified.
-    nixFile=$PWD
-fi
+        type=lambda p: Path(p).resolve(strict=True),
+        # Nix defaults to current directory when file not specified.
+        default=Path.cwd(),
+        help='evaluate FILE rather than the default',
+    )
+    parser.add_argument(
+        '--show-trace',
+        dest='show_trace',
+        action='store_true',
+        help='show trace when error occurs',
+    )
+    parser.add_argument(
+        'attr_paths',
+        metavar='attr-path',
+        nargs='+',
+        help='Attribute path of package to update',
+    )
 
-attrsNix="[ "
-namePositions="[ "
+    args = parser.parse_args()
 
-for attr in "${attrPaths[@]}"; do
-    buildArgs+=(-A "$attr")
-
-    attrsNix+="$(escapeNixString "$attr") "
-
-    namePositions+="($(nix-instantiate --eval -E "(let drv = (import $nixFile {}).${attr}; pname = builtins.unsafeGetAttrPos ''pname'' drv; in if pname != null then pname else builtins.unsafeGetAttrPos ''name'' drv)")) "
-done
-
-attrsNix+="]"
-namePositions+="]"
-
-buildArgs+=(--no-out-link)
-
-# Our overlays need to know the built attributes so that they can check only them.
-# We do it by using functions that return overlays so we need to instantiate them.
-saturatedOverlaysPath=$(mktemp -d)
-echo $saturatedOverlaysPath
-for f in $overlaysPath/*; do
-    overlay=$(basename "$f")
-    echo > "${saturatedOverlaysPath}/${overlay}" \
-        "import ${overlaysPath}/${overlay} { builtAttrs = $attrsNix; packageSet = $nixFile; namePositions = $namePositions; }"
-done
-
-buildArgs+=(-I "nixpkgs-overlays=$saturatedOverlaysPath")
-
-nix-build "${buildArgs[@]}"
+    main(args)


### PR DESCRIPTION
Instead of printing the warnings in the `checkMkDerivationFor` function in Nix using `builtins.trace`, let’s pass the messages through an attribute and extract them as a JSON object during evaluation triggered by the tool.
    
This will rid us of the ugly “trace: ” prefix and also allow us to more easily control which overlays are used.

To make this easier, I also ported the tool to Python. Getting rid of bash is always nice.

cc @SuperSandro2000