### PR TITLE
Add support for buildPythonPackage

### DIFF
--- a/explanations/duplicate-check-inputs.md
+++ b/explanations/duplicate-check-inputs.md
@@ -1,0 +1,3 @@
+In Python package expressions, `propagatedBuildInputs` is used to list dependencies that are required to be available at runtime. `checkInputs` lists dependencies that are required specifically during the `checkPhase`.
+
+All dependencies from `propagatedBuildInputs` are available during `checkPhase`, so there is no need to duplicate them in the `checkInputs`.

--- a/explanations/python-explicit-check-phase.md
+++ b/explanations/python-explicit-check-phase.md
@@ -1,0 +1,60 @@
+Nixpkgs contains a [`pytestCheckHook`](https://nixos.org/manual/nixpkgs/unstable/#using-pytestcheckhook) that can automatically run tests using pytest.
+
+For example, rather than
+
+```nix
+buildPythonPackage {
+  checkInputs = [
+    pytest
+    …
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+}
+```
+
+consider using
+
+```nix
+buildPythonPackage {
+  checkInputs = [
+    pytestCheckHook
+    …
+  ];
+}
+```
+
+Also note that many flags that you might want to pass to `pytest` can be passed automatically through `pytestCheckHook`.
+
+`buildPythonPackage` accepts:
+
+- `disabledTests` to disable particular pytest tests.
+- `disabledTestFiles` to disable particular pytest files.
+- `pytestFlagsArray` to pass flags to pytest. This should not be used to disable tests or test files.
+
+
+Here is a complete example using `pytestCheckHook`, `pytestFlagsArray`, and `disabledTests` and `disabledTestFiles`:
+
+```nix
+buildPythonPackage {
+  …
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "--timeout=30"
+  ];
+
+  disabledTests = [
+    "test_function_1"
+  ];
+
+  disabledTestFiles = [
+    "tests/some_file.py"
+  ];
+}
+```

--- a/explanations/python-imports-check-typo.md
+++ b/explanations/python-imports-check-typo.md
@@ -1,0 +1,18 @@
+When a Python package not provide tests, or making them pass in Nixpkgs is too difficult, expression should contain at least [`pythonImportsCheck`](https://nixos.org/manual/nixpkgs/unstable/#using-pythonimportscheck) to check that each of the modules declared by the package can be `import`ed. This effectively tests for many packaging errors.
+
+`pythonImportsCheck` can be used like this:
+
+```nix
+buildPythonPackage {
+  pname = "mymodule";
+  version = "1.0.0";
+
+  src = …;
+
+  pythonImportsCheck = [
+    "mymodule"
+  ];
+}
+```
+
+Note: it is easy to make a typo in the key `pythonImportsCheck` here, so watch out for that.

--- a/explanations/python-include-tests.md
+++ b/explanations/python-include-tests.md
@@ -1,0 +1,7 @@
+Some level of testing should be done for each Python package expression.
+
+If the `checkPhase` reports there are no tests, it might be necessary to:
+
+- If the tests are in a different directory than `tests/`, tell [`pytest`](https://nixos.org/manual/nixpkgs/unstable/#using-pytest) or [`pytestCheckHook`](https://nixos.org/manual/nixpkgs/unstable/#using-pytestcheckhook) where to find them.
+- If the upstream source code repository contains tests but they are not shipped with package on PyPI, switch to fetching from the repository (e.g. using `fetchFromGitHub`) and open an issue upstream asking to ship tests in the PyPI packages ([example](https://github.com/gnome-keysign/babel-glade/issues/5)).
+- If the package does not contain any tests, add `doCheck = false;` with a comment that there are no tests, and a [`pythonImportsCheck`](https://nixos.org/manual/nixpkgs/unstable/#using-pythonimportscheck) as a smoke test.

--- a/explanations/python-inconsistent-interpreters.md
+++ b/explanations/python-inconsistent-interpreters.md
@@ -1,0 +1,37 @@
+Each Python package expression in nixpkgs should take its inputs in such a way that it can be properly built for multiple different Python interpreters.
+
+For example, the following is incorrect:
+
+```nix
+{ lib
+, buildPythonPackage
+, python3Packages
+}:
+
+buildPythonPackage rec {
+  pname = "mypackage";
+  …
+  propagatedBuildInputs = [
+    python3Packages.numpy
+  ];
+}
+```
+
+Instead, it should be:
+
+```nix
+{ lib
+, buildPythonPackage
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "mypackage";
+  …
+  propagatedBuildInputs = [
+    numpy
+  ];
+}
+```
+
+This design allows nixpkgs to ensure that the version of Python pulled in by `numpy` is the same as the version that the package uses.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -25,6 +25,9 @@ rec {
       };
     };
 
+  # Identity element for overlays.
+  idOverlay = final: prev: {};
+
   # Creates a function based on the original one, that, when called on
   # one of the requested packages, runs a check on the arguments passed to it
   # and then returns the original result enriched with the reports.
@@ -67,4 +70,50 @@ rec {
         mkDerivation = wrapFunctionWithChecks prev.stdenv.mkDerivation namePositions check;
       };
     };
+
+    # Creates an overlay that replaces buildPythonPackage with a function that,
+    # for packages with locations of name attribute matching one of the namePositions,
+    # checks the attribute set passed as argument
+    checkBuildPythonPackageFor =
+      check:
+      {
+        namePositions
+        , ...
+      }:
+      final:
+      prev:
+
+      let
+        # Keep in sync with Nixpkgs’s all-packages.nix.
+        pythonPackageSetNames = [
+          "python"
+          "python2"
+          "python3"
+          "pypy"
+          "pypy2"
+          "pypy3"
+          "python27"
+          "python36"
+          "python37"
+          "python38"
+          "python39"
+          "python310"
+          "python3Minimal"
+          "pypy27"
+          "pypy36"
+        ];
+
+      in
+        lib.genAttrs pythonPackageSetNames (pythonName:
+          prev.${pythonName}.override (oldOverrides: {
+            packageOverrides = lib.composeExtensions (oldOverrides.packageOverrides or idOverlay) (final: prev: {
+              buildPythonPackage = wrapFunctionWithChecks prev.buildPythonPackage namePositions check;
+            });
+          }));
+
+    checkFor = check:
+      let
+        o1 = (checkMkDerivationFor check);
+        o2 = (checkBuildPythonPackageFor check);
+      in attrs: lib.composeExtensions (o1 attrs) (o2 attrs);
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -21,7 +21,7 @@ rec {
 
     lib.recursiveUpdate originalDrv {
       __nixpkgs-hammering-state = {
-        reports = originalDrv.__nixpkgs-hammering-state.reports or [] ++ reports;
+        reports = lib.unique (originalDrv.__nixpkgs-hammering-state.reports or [] ++ reports);
       };
     };
 

--- a/overlays/attribute-ordering.nix
+++ b/overlays/attribute-ordering.nix
@@ -6,7 +6,7 @@
 final: prev:
 let
   inherit (prev) lib;
-  inherit (import ../lib { inherit lib; }) checkMkDerivationFor;
+  inherit (import ../lib { inherit lib; }) checkFor;
 
   preferredOrdering =
     let
@@ -55,4 +55,4 @@ let
       );
 
 in
-  checkMkDerivationFor checkDerivation attrs final prev
+  checkFor checkDerivation attrs final prev

--- a/overlays/duplicate-check-inputs.nix
+++ b/overlays/duplicate-check-inputs.nix
@@ -1,0 +1,33 @@
+{ builtAttrs
+, packageSet
+, namePositions
+}@attrs:
+
+final: prev:
+let
+  inherit (prev) lib;
+  inherit (import ../lib { inherit lib; }) checkFor;
+
+  checkDerivation = drvArgs: drv:
+    let
+      list1 = drvArgs.propagatedBuildInputs or [];
+      list2 = drvArgs.checkInputs or [];
+      intersection = lib.intersectLists list1 list2;
+    in
+      lib.singleton {
+        name = "duplicate-check-inputs";
+        cond = builtins.length intersection > 0;
+        msg = ''
+          Dependencies listed in `propagatedBuildInputs` should not be repeated in `checkInputs`.
+
+          Detected duplicates:
+
+          ${lib.concatMapStringsSep "\n" (n: "- ${n}") (map (d: d.name) intersection)}
+        '';
+        locations = [
+          (builtins.unsafeGetAttrPos "checkInputs" drvArgs)
+          (builtins.unsafeGetAttrPos "propagatedBuildInputs" drvArgs)
+        ];
+      };
+in
+  checkFor checkDerivation attrs final prev

--- a/overlays/python-explicit-check-phase.nix
+++ b/overlays/python-explicit-check-phase.nix
@@ -1,0 +1,24 @@
+{ builtAttrs
+, packageSet
+, namePositions
+}@attrs:
+
+final: prev:
+let
+  inherit (prev) lib;
+  inherit (import ../lib { inherit lib; }) checkBuildPythonPackageFor;
+  regex = "[[:space:]]*pytest[[:space:]]*";
+
+  checkDerivation = drvArgs: drv:
+    lib.singleton {
+      name = "python-explicit-check-phase";
+      cond = (drvArgs ? checkPhase) && (builtins.match regex drvArgs.checkPhase) != null;
+      msg = ''
+        Consider using `pytestCheckHook` in `checkInputs` rather than `checkPhase = "pytest";`.
+      '';
+      locations = [
+        (builtins.unsafeGetAttrPos "checkPhase" drvArgs)
+      ];
+    };
+in
+  checkBuildPythonPackageFor checkDerivation attrs final prev

--- a/overlays/python-imports-check-typo.nix
+++ b/overlays/python-imports-check-typo.nix
@@ -1,0 +1,33 @@
+{ builtAttrs
+, packageSet
+, namePositions
+}@attrs:
+
+final: prev:
+let
+  inherit (prev) lib;
+  inherit (import ../lib { inherit lib; }) checkBuildPythonPackageFor;
+
+  incorrectSpellings = [
+    "pythonImportTests"
+    "pythonImportCheck"
+    "pythonImportsTest"
+    "pythonCheckImports"
+  ];
+
+  checkDerivation = drvArgs: drv:
+    (map
+      (incorrectSpelling: {
+        name = "python-imports-check-typo";
+        cond = builtins.hasAttr incorrectSpelling drvArgs;
+        msg = ''
+          A typo in `pythonImportsCheck` was found.
+        '';
+        locations = [
+          (builtins.unsafeGetAttrPos incorrectSpelling drvArgs)
+        ];
+      })
+      incorrectSpellings
+    );
+in
+  checkBuildPythonPackageFor checkDerivation attrs final prev

--- a/overlays/python-include-tests.nix
+++ b/overlays/python-include-tests.nix
@@ -1,0 +1,29 @@
+{ builtAttrs
+, packageSet
+, namePositions
+}@attrs:
+
+final: prev:
+let
+  inherit (prev) lib;
+  inherit (import ../lib { inherit lib; }) checkBuildPythonPackageFor;
+
+  checkDerivation = drvArgs: drv:
+    lib.singleton {
+      name = "python-include-tests";
+      cond =
+        let
+          hasCheckPhase = drvArgs ? checkPhase;
+          hasDoCheckFalse = (drvArgs ? doCheck) && (drvArgs.doCheck == false);
+          hasPytestCheckHook = drvArgs ? checkInputs && lib.any (n: n.name == "pytest-check-hook") drvArgs.checkInputs;
+          hasPythonImportsCheck = drvArgs ? pythonImportsCheck;
+
+          hasActiveCheckPhase = (hasCheckPhase || hasPytestCheckHook) && (!hasDoCheckFalse);
+        in
+          !(hasActiveCheckPhase || hasPythonImportsCheck);
+      msg = ''
+        Add a `checkPhase` for tests, or at least `pythonImportsCheck`.
+      '';
+    };
+in
+  checkBuildPythonPackageFor checkDerivation attrs final prev

--- a/overlays/python-inconsistent-interpreters.nix
+++ b/overlays/python-inconsistent-interpreters.nix
@@ -1,0 +1,43 @@
+{ builtAttrs
+, packageSet
+, namePositions
+}@attrs:
+
+final: prev:
+let
+  inherit (prev) lib;
+  inherit (import ../lib { inherit lib; }) checkBuildPythonPackageFor;
+
+  checkDerivation = drvArgs: drv:
+    let
+      propagatedBuildInputs = drvArgs.propagatedBuildInputs or [];
+      checkInputs = drvArgs.checkInputs or [];
+      runtimeInputs = checkInputs ++ propagatedBuildInputs;
+      inputPythonInterpreters = map (p: p.pythonModule) (builtins.filter (p: p ? pythonModule) runtimeInputs);
+      allPythonInterpreters = lib.unique (inputPythonInterpreters ++ [ drv.pythonModule ]);
+    in
+      lib.singleton {
+        name = "python-inconsistent-interpreters";
+        cond = builtins.length allPythonInterpreters > 1;
+        msg =
+          let
+            allPythonNames = map (p: p.name) allPythonInterpreters;
+            sources = [
+              "buildPythonPackage"
+            ] ++ lib.optionals (builtins.any (p: p.pythonModule or drv.pythonModule != drv.pythonModule) propagatedBuildInputs) [
+              "propagatedBuildInputs"
+            ] ++ lib.optionals (builtins.any (p: p.pythonModule or drv.pythonModule != drv.pythonModule) checkInputs) [
+              "checkInputs"
+            ];
+          in ''
+            Between ${lib.concatStringsSep " and " sources}, this derivation seems
+            to be simultaneously trying to use packages from multiple different Python package sets.
+            Mixing package sets like this is not supported.
+
+            Detected Python packages:
+
+            ${lib.concatMapStringsSep "\n" (p: "- ${p}") allPythonNames}
+          '';
+      };
+  in
+checkBuildPythonPackageFor checkDerivation attrs final prev

--- a/overlays/unclear-gpl.nix
+++ b/overlays/unclear-gpl.nix
@@ -6,7 +6,7 @@
 final: prev:
 let
   inherit (prev) lib;
-  inherit (import ../lib { inherit lib; }) checkMkDerivationFor;
+  inherit (import ../lib { inherit lib; }) checkFor;
 
   licenses = [
     "agpl3"
@@ -37,4 +37,4 @@ let
     );
 
 in
-  checkMkDerivationFor checkDerivation attrs final prev
+  checkFor checkDerivation attrs final prev

--- a/run-tests.py
+++ b/run-tests.py
@@ -144,6 +144,19 @@ class TestSuite(unittest.TestSuite):
         )
 
         yield make_test_rule(
+            'python-include-tests',
+            [
+                'no-tests-no-import-checks',
+                'tests-disabled-no-import-checks',
+            ],
+            [
+                'pytest-check-hook',
+                'explicit-check-phase',
+                'has-imports-check'
+            ]
+        )
+
+        yield make_test_rule(
             'unnecessary-parallel-building',
             [
                 'cmake',

--- a/run-tests.py
+++ b/run-tests.py
@@ -161,6 +161,17 @@ class TestSuite(unittest.TestSuite):
         )
 
         yield make_test_rule(
+            'python-inconsistent-interpreters',
+            [
+                'mixed-1',
+                'mixed-2',
+            ],
+            [
+                'normal',
+            ]
+        )
+
+        yield make_test_rule(
             'unnecessary-parallel-building',
             [
                 'cmake',

--- a/run-tests.py
+++ b/run-tests.py
@@ -81,6 +81,10 @@ class TestSuite(unittest.TestSuite):
         )
 
         yield make_test_rule(
+            'duplicate-check-inputs',
+        )
+
+        yield make_test_rule(
             'explicit-phases',
             [
                 'configure',

--- a/run-tests.py
+++ b/run-tests.py
@@ -194,6 +194,7 @@ class TestSuite(unittest.TestSuite):
                 'lgpl2',
                 'lgpl21',
                 'lgpl3',
+                'lgpl3-python',
             ],
             [
                 'single-nonmatching-license',

--- a/run-tests.py
+++ b/run-tests.py
@@ -121,6 +121,17 @@ class TestSuite(unittest.TestSuite):
         )
 
         yield make_test_rule(
+            'python-explicit-check-phase',
+            [
+                'redundant-pytest',
+            ],
+            [
+                'nonredundant-pytest',
+            ]
+        )
+
+
+        yield make_test_rule(
             'unnecessary-parallel-building',
             [
                 'cmake',

--- a/run-tests.py
+++ b/run-tests.py
@@ -130,6 +130,18 @@ class TestSuite(unittest.TestSuite):
             ]
         )
 
+        yield make_test_rule(
+            'python-imports-check-typo',
+            [
+                'pythonImportTests',
+                'pythonImportCheck',
+                'pythonImportsTest',
+                'pythonCheckImports',
+            ],
+            [
+                'pythonImportsCheck',
+            ]
+        )
 
         yield make_test_rule(
             'unnecessary-parallel-building',

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -12,6 +12,7 @@
   patch-phase = pkgs.callPackage ./patch-phase { };
   python-explicit-check-phase = pkgs.python3.pkgs.callPackage ./python-explicit-check-phase { };
   python-imports-check-typo = pkgs.python3.pkgs.callPackage ./python-imports-check-typo { };
+  python-include-tests = pkgs.python3.pkgs.callPackage ./python-include-tests { };
   unclear-gpl = pkgs.callPackage ./unclear-gpl { };
   unnecessary-parallel-building = pkgs.callPackage ./unnecessary-parallel-building { };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -11,6 +11,7 @@
   missing-phase-hooks = pkgs.callPackage ./missing-phase-hooks { };
   patch-phase = pkgs.callPackage ./patch-phase { };
   python-explicit-check-phase = pkgs.python3.pkgs.callPackage ./python-explicit-check-phase { };
+  python-imports-check-typo = pkgs.python3.pkgs.callPackage ./python-imports-check-typo { };
   unclear-gpl = pkgs.callPackage ./unclear-gpl { };
   unnecessary-parallel-building = pkgs.callPackage ./unnecessary-parallel-building { };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -5,6 +5,7 @@
 {
   attribute-ordering = pkgs.callPackage ./attribute-ordering { };
   build-tools-in-build-inputs = pkgs.recurseIntoAttrs (pkgs.callPackage ./build-tools-in-build-inputs { });
+  duplicate-check-inputs = pkgs.python3.pkgs.callPackage ./duplicate-check-inputs { };
   explicit-phases = pkgs.callPackage ./explicit-phases { };
   fixup-phase = pkgs.callPackage ./fixup-phase { };
   meson-cmake = pkgs.callPackage ./meson-cmake { };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -10,6 +10,7 @@
   meson-cmake = pkgs.callPackage ./meson-cmake { };
   missing-phase-hooks = pkgs.callPackage ./missing-phase-hooks { };
   patch-phase = pkgs.callPackage ./patch-phase { };
+  python-explicit-check-phase = pkgs.python3.pkgs.callPackage ./python-explicit-check-phase { };
   unclear-gpl = pkgs.callPackage ./unclear-gpl { };
   unnecessary-parallel-building = pkgs.callPackage ./unnecessary-parallel-building { };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -14,6 +14,7 @@
   python-explicit-check-phase = pkgs.python3.pkgs.callPackage ./python-explicit-check-phase { };
   python-imports-check-typo = pkgs.python3.pkgs.callPackage ./python-imports-check-typo { };
   python-include-tests = pkgs.python3.pkgs.callPackage ./python-include-tests { };
+  python-inconsistent-interpreters = pkgs.python3.pkgs.callPackage ./python-inconsistent-interpreters { };
   unclear-gpl = pkgs.callPackage ./unclear-gpl { };
   unnecessary-parallel-building = pkgs.callPackage ./unnecessary-parallel-building { };
 }

--- a/tests/duplicate-check-inputs/default.nix
+++ b/tests/duplicate-check-inputs/default.nix
@@ -1,0 +1,12 @@
+{ buildPythonPackage
+, numpy
+}:
+
+buildPythonPackage {
+  pname = "patch-phase";
+
+  src = ../fixtures/make;
+
+  propagatedBuildInputs = [ numpy ];
+  checkInputs = [ numpy ];
+}

--- a/tests/python-explicit-check-phase/default.nix
+++ b/tests/python-explicit-check-phase/default.nix
@@ -1,0 +1,10 @@
+{ callPackage
+}:
+
+{
+  # positive cases
+  redundant-pytest = callPackage ./redundant-pytest.nix { };
+
+  # negative cases
+  nonredundant-pytest = callPackage ./nonredundant-pytest.nix { };
+}

--- a/tests/python-explicit-check-phase/nonredundant-pytest.nix
+++ b/tests/python-explicit-check-phase/nonredundant-pytest.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "redundant-pytest";
+
+  src = ../fixtures/make;
+
+  checkPhase = "  pytest -some-nonstandard-flag ";
+}

--- a/tests/python-explicit-check-phase/redundant-pytest.nix
+++ b/tests/python-explicit-check-phase/redundant-pytest.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "redundant-pytest";
+
+  src = ../fixtures/make;
+
+  checkPhase = "  pytest ";
+}

--- a/tests/python-imports-check-typo/default.nix
+++ b/tests/python-imports-check-typo/default.nix
@@ -1,0 +1,13 @@
+{ callPackage
+}:
+
+{
+  # positive cases
+  pythonImportTests = callPackage ./pythonImportTests.nix { };
+  pythonImportCheck = callPackage ./pythonImportCheck.nix { };
+  pythonImportsTest = callPackage ./pythonImportsTest.nix { };
+  pythonCheckImports = callPackage ./pythonCheckImports.nix { };
+
+  # negative cases
+  pythonImportsCheck = callPackage ./pythonImportsCheck.nix { };
+}

--- a/tests/python-imports-check-typo/pythonCheckImports.nix
+++ b/tests/python-imports-check-typo/pythonCheckImports.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "pythonCheckImports";
+
+  src = ../fixtures/make;
+
+  pythonCheckImports = [];
+}

--- a/tests/python-imports-check-typo/pythonImportCheck.nix
+++ b/tests/python-imports-check-typo/pythonImportCheck.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "pythonImportCheck";
+
+  src = ../fixtures/make;
+
+  pythonImportCheck = [];
+}

--- a/tests/python-imports-check-typo/pythonImportTests.nix
+++ b/tests/python-imports-check-typo/pythonImportTests.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "pythonImportTests";
+
+  src = ../fixtures/make;
+
+  pythonImportTests = [];
+}

--- a/tests/python-imports-check-typo/pythonImportsCheck.nix
+++ b/tests/python-imports-check-typo/pythonImportsCheck.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "pythonImportsCheck";
+
+  src = ../fixtures/make;
+
+  pythonImportsCheck = [];
+}

--- a/tests/python-imports-check-typo/pythonImportsTest.nix
+++ b/tests/python-imports-check-typo/pythonImportsTest.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "pythonImportsTest";
+
+  src = ../fixtures/make;
+
+  pythonImportsTest = [];
+}

--- a/tests/python-include-tests/default.nix
+++ b/tests/python-include-tests/default.nix
@@ -1,0 +1,13 @@
+{ callPackage
+}:
+
+{
+  # positive cases
+  no-tests-no-import-checks = callPackage ./no-tests-no-import-checks.nix { };
+  tests-disabled-no-import-checks = callPackage ./tests-disabled-no-import-checks.nix { };
+
+  # negative cases
+  pytest-check-hook = callPackage ./pytest-check-hook.nix { };
+  explicit-check-phase = callPackage ./explicit-check-phase.nix { };
+  has-imports-check = callPackage ./has-imports-check.nix { };
+}

--- a/tests/python-include-tests/explicit-check-phase.nix
+++ b/tests/python-include-tests/explicit-check-phase.nix
@@ -1,0 +1,10 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "package";
+
+  src = ../fixtures/make;
+
+  checkPhase = "";
+}

--- a/tests/python-include-tests/has-imports-check.nix
+++ b/tests/python-include-tests/has-imports-check.nix
@@ -1,0 +1,11 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "package";
+
+  src = ../fixtures/make;
+
+  pythonImportsCheck = [
+  ];
+}

--- a/tests/python-include-tests/no-tests-no-import-checks.nix
+++ b/tests/python-include-tests/no-tests-no-import-checks.nix
@@ -1,0 +1,8 @@
+{ buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "package";
+
+  src = ../fixtures/make;
+}

--- a/tests/python-include-tests/pytest-check-hook.nix
+++ b/tests/python-include-tests/pytest-check-hook.nix
@@ -1,0 +1,13 @@
+{ buildPythonPackage
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "package";
+
+  src = ../fixtures/make;
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+}

--- a/tests/python-include-tests/tests-disabled-no-import-checks.nix
+++ b/tests/python-include-tests/tests-disabled-no-import-checks.nix
@@ -1,0 +1,15 @@
+{ buildPythonPackage
+, pytestCheckHook
+}:
+
+buildPythonPackage {
+  pname = "package";
+
+  src = ../fixtures/make;
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  doCheck = false;
+}

--- a/tests/python-inconsistent-interpreters/default.nix
+++ b/tests/python-inconsistent-interpreters/default.nix
@@ -1,0 +1,11 @@
+{ callPackage
+}:
+
+{
+  # positive cases
+  mixed-1 = callPackage ./mixed-1.nix { };
+  mixed-2 = callPackage ./mixed-2.nix { };
+
+  # negative cases
+  normal = callPackage ./normal.nix { };
+}

--- a/tests/python-inconsistent-interpreters/mixed-1.nix
+++ b/tests/python-inconsistent-interpreters/mixed-1.nix
@@ -1,0 +1,13 @@
+{ buildPythonPackage
+, python37Packages
+, python39Packages
+}:
+
+buildPythonPackage rec {
+  pname = "package";
+
+  propagatedBuildInputs = [
+    python37Packages.numpy
+    python39Packages.scipy
+  ];
+}

--- a/tests/python-inconsistent-interpreters/mixed-2.nix
+++ b/tests/python-inconsistent-interpreters/mixed-2.nix
@@ -1,0 +1,11 @@
+{ buildPythonPackage
+, python27Packages
+}:
+
+buildPythonPackage rec {
+  pname = "package";
+
+  checkInputs = [
+    python27Packages.numpy
+  ];
+}

--- a/tests/python-inconsistent-interpreters/normal.nix
+++ b/tests/python-inconsistent-interpreters/normal.nix
@@ -1,0 +1,13 @@
+{ buildPythonPackage
+, numpy
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "package";
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+  ];
+}

--- a/tests/unclear-gpl/default.nix
+++ b/tests/unclear-gpl/default.nix
@@ -13,6 +13,7 @@
   lgpl2 = pkgs.callPackage ./lgpl2.nix { };
   lgpl21 = pkgs.callPackage ./lgpl21.nix { };
   lgpl3 = pkgs.callPackage ./lgpl3.nix { };
+  lgpl3-python = pkgs.python3.pkgs.callPackage ./lgpl3-python.nix { };
 
   # negative cases
   single-nonmatching-license = pkgs.callPackage ./single-nonmatching-license.nix { };

--- a/tests/unclear-gpl/lgpl3-python.nix
+++ b/tests/unclear-gpl/lgpl3-python.nix
@@ -1,0 +1,11 @@
+{ lib
+, buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "unclear-gpl-lgpl3-python";
+
+  src = ../fixtures/make;
+
+  meta.license = [ lib.licenses.lgpl3 ];
+}


### PR DESCRIPTION
Hi @jtojnar:

I've started trying to add support for checking the arguments to buildPythonPackage as an addition to the current checking of the arguments to mkDerivation. So far, it appears to mostly work, although I can't yet seem to get it to report multiple failures at once -- the checks appear to short-circuit once a single failing check is identified.

Still WIP, but I wanted to post this now for any feedback.