### PR TITLE
Fix AttrPathNotFound detection

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,6 +4,8 @@
 rec {
   attrByPathString = attrPath: lib.getAttrFromPath (lib.splitString "." attrPath);
 
+  inherit (import ./standalone.nix) getDrvSourceLocation;
+
   capitalize = str:
     if builtins.stringLength str == 0 then
       str
@@ -40,11 +42,7 @@ rec {
 
     let
       originalDrv = originalFunction args;
-      namePosition =
-        let
-          pnamePosition = builtins.unsafeGetAttrPos "pname" args;
-        in
-          if pnamePosition != null then pnamePosition else builtins.unsafeGetAttrPos "name" args;
+      namePosition = getDrvSourceLocation args;
     in
       if builtins.elem namePosition namePositions
       then

--- a/lib/standalone.nix
+++ b/lib/standalone.nix
@@ -1,0 +1,14 @@
+# Set of functions depending just on builtins,
+# to be shared between the checks and the tool.
+{
+  # Get location of the source code of a derivation.
+  # This is roughly equivalent to `meta.position` used by nix edit.
+  getDrvSourceLocation = drv:
+    let
+      pnamePosition = builtins.unsafeGetAttrPos "pname" drv;
+    in
+      if pnamePosition != null then
+        pnamePosition
+      else
+        builtins.unsafeGetAttrPos "name" drv;
+}

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -15,9 +15,14 @@ def escape_nix_string(val: str) -> str:
     return '"' + val.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
 
-def nix_eval_json(expr: str):
+def nix_eval_json(expr: str, show_trace: bool=False):
+    args = [NIX_INSTANTIATE_PATH, '--strict', '--json', '--eval', '-E', expr]
+
+    if show_trace:
+        args.append('--show-trace')
+
     result = subprocess.check_output(
-        [NIX_INSTANTIATE_PATH, '--strict', '--json', '--eval', '-E', expr],
+        args,
         encoding='utf-8',
     )
     return json.loads(result)
@@ -80,13 +85,6 @@ def main(args):
     script_dir = Path(__file__).parent
     overlay_generators_path = (script_dir.parent / 'overlays').absolute()
     lib_dir = (script_dir.parent / 'lib').absolute()
-
-    build_args = [
-        args.nix_file,
-    ]
-
-    if args.show_trace:
-        build_args.append('--show-trace')
 
     attrs_nix = []
     attr_messages = []
@@ -156,7 +154,7 @@ def main(args):
     if args.show_trace:
         print('Nix expression:', all_messages_nix, file=sys.stderr)
 
-    all_messages = nix_eval_json(all_messages_nix)
+    all_messages = nix_eval_json(all_messages_nix, args.show_trace)
 
     if args.json:
         print(json.dumps(all_messages))

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -110,7 +110,7 @@ def main(args):
         name_position = textwrap.dedent(
             f'''
             let
-                drv = (import {args.nix_file} {{ }}).{attr} or {{ }};
+                drv = cleanPkgs.{attr} or {{ }};
             in
                 getDrvSourceLocation drv
             '''
@@ -142,6 +142,7 @@ def main(args):
             inherit (import {lib_dir / 'standalone.nix'}) getDrvSourceLocation;
             builtAttrs = [ {" ".join(attrs_nix)} ];
             packageSet = {args.nix_file};
+            cleanPkgs = import {args.nix_file} {{ }};
             namePositions = builtins.filter (p: p != null) {indent(name_positions_nix, 2 + 1).strip()};
 
             pkgs = import {args.nix_file} {{

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -118,7 +118,7 @@ def main(args):
         name_position = nix_eval(textwrap.dedent(
             f'''
             let
-                drv = (import {args.nix_file} {{ }}).{attr};
+                drv = (import {args.nix_file} {{ }}).{attr} or {{ }};
                 pname = builtins.unsafeGetAttrPos "pname" drv;
             in
                 if pname != null then
@@ -153,7 +153,7 @@ def main(args):
         let
             builtAttrs = [ {" ".join(attrs_nix)} ];
             packageSet = {args.nix_file};
-            namePositions = {indent(name_positions_nix, 2 + 1).strip()};
+            namePositions = builtins.filter (p: p != null) {indent(name_positions_nix, 2 + 1).strip()};
 
             pkgs = import {args.nix_file} {{
                 overlays = {indent(overlays_nix, 2 + 2).strip()};

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -15,12 +15,12 @@ def escape_nix_string(val: str) -> str:
     return '"' + val.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
 
-def nix_eval_json(expr: str, as_string=False):
+def nix_eval_json(expr: str):
     result = subprocess.check_output(
         [NIX_INSTANTIATE_PATH, '--strict', '--json', '--eval', '-E', expr],
         encoding='utf-8',
     )
-    return result if as_string else json.loads(result)
+    return json.loads(result)
 
 
 def bold(msg):
@@ -156,10 +156,10 @@ def main(args):
     if args.show_trace:
         print('Nix expression:', all_messages_nix, file=sys.stderr)
 
-    all_messages = nix_eval_json(all_messages_nix, args.json)
+    all_messages = nix_eval_json(all_messages_nix)
 
     if args.json:
-        print(all_messages)
+        print(json.dumps(all_messages))
     else:
         for attr, messages in all_messages.items():
             print(bold(f'When evaluating attribute ‘{attr}’:'), file=sys.stderr)

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -79,6 +79,7 @@ def stringify_message(name, msg, locations=[], cond=True, link=True, severity='w
 def main(args):
     script_dir = Path(__file__).parent
     overlay_generators_path = (script_dir.parent / 'overlays').absolute()
+    lib_dir = (script_dir.parent / 'lib').absolute()
 
     build_args = [
         args.nix_file,
@@ -112,12 +113,8 @@ def main(args):
             f'''
             let
                 drv = (import {args.nix_file} {{ }}).{attr} or {{ }};
-                pname = builtins.unsafeGetAttrPos "pname" drv;
             in
-                if pname != null then
-                    pname
-                else
-                    builtins.unsafeGetAttrPos "name" drv
+                getDrvSourceLocation drv
             '''
         )
         name_positions.append('(' + name_position.strip() + ')')
@@ -144,6 +141,7 @@ def main(args):
     all_messages_nix = textwrap.dedent(
         f'''
         let
+            inherit (import {lib_dir / 'standalone.nix'}) getDrvSourceLocation;
             builtAttrs = [ {" ".join(attrs_nix)} ];
             packageSet = {args.nix_file};
             namePositions = builtins.filter (p: p != null) {indent(name_positions_nix, 2 + 1).strip()};

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -15,13 +15,6 @@ def escape_nix_string(val: str) -> str:
     return '"' + val.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
 
-def nix_eval(expr: str) -> str:
-    return subprocess.check_output(
-        [NIX_INSTANTIATE_PATH, '--eval', '-E', expr],
-        encoding='utf-8',
-    )
-
-
 def nix_eval_json(expr: str, as_string=False):
     result = subprocess.check_output(
         [NIX_INSTANTIATE_PATH, '--strict', '--json', '--eval', '-E', expr],
@@ -115,7 +108,7 @@ def main(args):
             '''
         ))
 
-        name_position = nix_eval(textwrap.dedent(
+        name_position = textwrap.dedent(
             f'''
             let
                 drv = (import {args.nix_file} {{ }}).{attr} or {{ }};
@@ -126,7 +119,7 @@ def main(args):
                 else
                     builtins.unsafeGetAttrPos "name" drv
             '''
-        ))
+        )
         name_positions.append('(' + name_position.strip() + ')')
 
     # Our overlays need to know the built attributes so that they can check only them.


### PR DESCRIPTION
It probably never worked. Instead of crashing, let’s return `null` so that this can be detected in assertions.

Also fix `--show-trace` so that developers can see debug issues more easily.

cc @rmcgibbo 