### PR TITLE
Add unused-argument check

### DIFF
--- a/ast-checks/src/bin/missing-patch-comment.rs
+++ b/ast-checks/src/bin/missing-patch-comment.rs
@@ -56,9 +56,10 @@ fn process_patch_list(
                     let start = item.text_range().start().to_usize() as u32;
 
                     report.push(NixpkgsHammerMessage {
-                        msg: "Please add a comment on the line above, explaining the purpose of this patch.",
+                        msg: "Please add a comment on the line above, explaining the purpose of this patch.".to_string(),
                         name: "missing-patch-comment",
                         locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],
+                        link: true,
                     });
                 }
             }
@@ -67,9 +68,10 @@ fn process_patch_list(
             let start = kv.node().text_range().start().to_usize() as u32;
 
             report.push(NixpkgsHammerMessage {
-                msg: "`patches` should be a list.",
+                msg: "`patches` should be a list.".to_string(),
                 name: "missing-patch-comment",
                 locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],
+                link: true,
             });
         }
     };

--- a/ast-checks/src/bin/no-uri-literals.rs
+++ b/ast-checks/src/bin/no-uri-literals.rs
@@ -23,9 +23,10 @@ fn analyze_single_file(
         let start = uri.text_range().start().to_usize() as u32;
 
         report.push(NixpkgsHammerMessage {
-            msg: "URI literals are deprecated.",
+            msg: "URI literals are deprecated.".to_string(),
             name: "no-uri-literals",
             locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],
+            link: true,
         });
     }
 

--- a/ast-checks/src/bin/unused-argument.rs
+++ b/ast-checks/src/bin/unused-argument.rs
@@ -1,0 +1,94 @@
+use codespan::{FileId, Files};
+use nixpkgs_hammering_ast_checks::analysis::*;
+use nixpkgs_hammering_ast_checks::common_structs::*;
+use nixpkgs_hammering_ast_checks::tree_utils::walk_kind;
+use rnix::{types::*, SyntaxNode};
+use rnix::SyntaxKind::*;
+use std::{env, error::Error};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().skip(1).collect();
+    println!("{}", analyze_files(args, analyze_single_file)?);
+    Ok(())
+}
+
+fn analyze_single_file(files: &Files<String>, file_id: FileId) -> Result<Report, Box<dyn Error>> {
+    let root = find_root(files, file_id)?;
+    let mut report: Report = vec![];
+
+    // This check looks for unused variables by walking the AST. It has a very
+    // simple implementation: for each function that takes its arguments using
+    // a pattern contract, we record the names of the variables. Then, we walk through
+    // the body of the function and look for those names being used as identifiers. If
+    // we don't see them, we call it an unused variable.
+
+    // This design is simple and I don't believe that it produces any false positives,
+    // which would be highly undesirable. It does, however, produce some false negatives.
+    // Because we're not tracking all the intermediate scopes between the declaration of the
+    // formal parameter and its use in the function body, it's possible for inner functions,
+    // with statements, or let blocks that cause variables in the outer scope to be shadowed
+    // to make this check _think_ that a variable is used when it really wasn't.
+
+    // Fixing this behavior could be done by following the pseudocode in
+    // https://github.com/jtojnar/nixpkgs-hammering/pull/32#issuecomment-776936922
+    // but hasn't been done yet because we don't think rare false negatives are a high
+    // priority.
+
+    for lambda_elem in walk_kind(&root, NODE_LAMBDA) {
+        let lambda = lambda_elem.into_node().and_then(Lambda::cast);
+
+        let body = lambda
+            .clone()
+            .and_then(|l| l.body())
+            .ok_or("Unable to extract function body")?;
+        let identifiers_in_body: Vec<Ident> = walk_kind(&body, NODE_IDENT)
+            .filter_map(|elem| elem.into_node())
+            .filter_map(Ident::cast)
+            // Filter out identifiers that are acting as keys in an attrset
+            // i.e a construct like ```{
+            //   x = 1;
+            // }```
+            // does not mean that `x` is acting as a usage of the identifier
+            // `x` for purposes of detecting unused variables
+            .filter(|ident| !ident_is_attrset_key(ident.node()))
+            .collect();
+
+        // Extract the formal parameters from pattern-type functions, and don't
+        // extract anything from single-argument functions because they often
+        // need to have unused arguments for overlay-type constructs.
+        let pattern = lambda.and_then(|l| l.arg()).and_then(Pattern::cast);
+        let formal_parameter_pattern_args = match pattern {
+            Some(pattern) => pattern.entries().filter_map(|entry| entry.name()).collect(),
+            None => vec![],
+        };
+
+        let unused_formal_parameters = formal_parameter_pattern_args
+            .iter()
+            // Filter out formal parameters that are used as identifiers
+            // in the function body
+            .filter(|formal| {
+                !identifiers_in_body
+                    .iter()
+                    .any(|ident| ident.as_str() == formal.as_str())
+            });
+
+        for unused in unused_formal_parameters {
+            let start = unused.node().text_range().start().to_usize() as u32;
+            report.push(NixpkgsHammerMessage {
+                msg: format!("Unused argument: `{}`.", unused.node()),
+                name: "unused-argument",
+                locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],
+                link: false,
+            });
+        }
+    }
+
+    Ok(report)
+}
+
+fn ident_is_attrset_key(node: &SyntaxNode) -> bool {
+    match node.parent() {
+        Some(p) if p.kind() == NODE_KEY => true,
+        _ => false
+    }
+}

--- a/ast-checks/src/common_structs.rs
+++ b/ast-checks/src/common_structs.rs
@@ -33,6 +33,7 @@ impl SourceLocation {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NixpkgsHammerMessage {
     pub locations: Vec<SourceLocation>,
-    pub msg: &'static str,
+    pub msg: String,
     pub name: &'static str,
+    pub link: bool,
 }

--- a/run-tests.py
+++ b/run-tests.py
@@ -280,6 +280,21 @@ class TestSuite(unittest.TestSuite):
             ]
         )
 
+        yield make_test_rule(
+            'unused-argument',
+            [
+                'unused-pattern',
+                'unused-pattern-var-as-key',
+                'unused-pattern-var-in-let-binding',
+            ],
+            [
+                'used-pattern',
+                'used-single',
+                'unused-single',
+            ]
+        )
+
+
 def load_tests(loader, tests, pattern):
     return TestSuite()
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -24,4 +24,5 @@
   python-inconsistent-interpreters = pkgs.python3.pkgs.callPackage ./python-inconsistent-interpreters { };
   unclear-gpl = pkgs.callPackage ./unclear-gpl { };
   unnecessary-parallel-building = pkgs.callPackage ./unnecessary-parallel-building { };
+  unused-argument = pkgs.callPackage ./unused-argument {};
 }

--- a/tests/unused-argument/default.nix
+++ b/tests/unused-argument/default.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+
+{
+  # positive cases
+  unused-pattern = pkgs.callPackage ./unused-pattern.nix { };
+  unused-pattern-var-as-key = pkgs.callPackage ./unused-pattern-var-as-key.nix { };
+  unused-pattern-var-in-let-binding = pkgs.callPackage ./unused-pattern-var-in-let-binding.nix { };
+
+  # negative cases
+  used-pattern = pkgs.callPackage ./used-pattern.nix {
+    var1 = 1;
+    var2 = 2;
+  };
+  used-single = pkgs.callPackage ./used-single.nix { };
+  unused-single = pkgs.callPackage ./unused-single.nix { };
+}

--- a/tests/unused-argument/unused-pattern-var-as-key.nix
+++ b/tests/unused-argument/unused-pattern-var-as-key.nix
@@ -1,0 +1,14 @@
+{ stdenv
+, unused
+}:
+
+stdenv.mkDerivation {
+  name = "unused-pattern";
+
+  src = ../fixtures/make;
+
+  # although we have the identifier 'unused' in the function body
+  # this does not count as usage for purposes of 'unused-argument'
+  # because of it's position as a key in an attrset
+  unused = 1;
+}

--- a/tests/unused-argument/unused-pattern-var-in-let-binding.nix
+++ b/tests/unused-argument/unused-pattern-var-in-let-binding.nix
@@ -1,0 +1,10 @@
+{ stdenv, unused }:
+
+stdenv.mkDerivation {
+  name = "unused-pattern";
+
+  # although we have the identifier 'unused' in the function body
+  # this does not count as usage for purposes of 'unused-argument'
+  # because of it's position as a key in an attrset
+  src = let unused = "foo"; in ../fixtures/make;
+}

--- a/tests/unused-argument/unused-pattern.nix
+++ b/tests/unused-argument/unused-pattern.nix
@@ -1,0 +1,9 @@
+{ stdenv
+, unused
+}:
+
+stdenv.mkDerivation {
+  name = "unused-pattern";
+
+  src = ../fixtures/make;
+}

--- a/tests/unused-argument/unused-single.nix
+++ b/tests/unused-argument/unused-single.nix
@@ -1,0 +1,9 @@
+{ stdenv
+}:
+
+stdenv.mkDerivation {
+  name = "unused-single";
+
+  src = ../fixtures/make;
+  function = unused: 1;
+}

--- a/tests/unused-argument/used-pattern.nix
+++ b/tests/unused-argument/used-pattern.nix
@@ -1,0 +1,13 @@
+{ stdenv
+, var1
+, var2
+}:
+
+stdenv.mkDerivation {
+  name = "used-pattern";
+
+  src = ../fixtures/make;
+  argument = {
+    inherit var1 var2;
+  };
+}

--- a/tests/unused-argument/used-single.nix
+++ b/tests/unused-argument/used-single.nix
@@ -1,0 +1,9 @@
+{ stdenv
+}:
+
+stdenv.mkDerivation {
+  name = "unused-single";
+
+  src = ../fixtures/make;
+  function = used: used + used;
+}


### PR DESCRIPTION
Still some work to be done, but I wanted to file the WIP before signing off for the night.

1. ~Doesn't handle `func = a: 1;`-type functions yet, only handles functions where the formal parameters are in a pattern struct (obviously needs to be fixed).~
2.  Not every possible unused argument is actually caught -- a construct  `{foo}: {foo = 1;}` will not show as having an unused argument even though it does, because the keyvalue key foo in the function body will be incorrectly identified as a use of the formal parameter. This might not actually need to be fixed.
3. Other scoping like with and let blocks that introduce new variables and cause variables in the outer scope to be shadowed aren't taken into account, so that's another source of false negatives.

But re (2,3), I don't think false negatives are that bad here. False positives would be the problem.