### PR TITLE
Fix issue #23

### DIFF
--- a/ast-checks/src/bin/missing-patch-comment.rs
+++ b/ast-checks/src/bin/missing-patch-comment.rs
@@ -2,9 +2,9 @@ use codespan::{FileId, Files};
 use nixpkgs_hammering_ast_checks::analysis::*;
 use nixpkgs_hammering_ast_checks::comment_finders::{find_comment_above, find_comment_within};
 use nixpkgs_hammering_ast_checks::common_structs::{NixpkgsHammerMessage, SourceLocation};
-use rnix::types::*;
-use std::{error::Error, env};
-use nixpkgs_hammering_ast_checks::tree_utils::walk_keyvalues_filter_key;
+use nixpkgs_hammering_ast_checks::tree_utils::{parents, walk_keyvalues_filter_key, walk_kind};
+use rnix::{types::*, SyntaxKind::*};
+use std::{env, error::Error};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -12,10 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn analyze_single_file(
-    files: &Files<String>,
-    file_id: FileId,
-) -> Result<Report, Box<dyn Error>> {
+fn analyze_single_file(files: &Files<String>, file_id: FileId) -> Result<Report, Box<dyn Error>> {
     let root = find_root(files, file_id)?;
     let mut report: Report = vec![];
 
@@ -30,51 +27,69 @@ fn analyze_single_file(
     // For each list of patches without a top comment,
     // produce a report for each patch that is missing a per-patch comment.
     for kv in patches_without_top_comment {
-        report.extend(process_patch_list(kv, files, file_id)?);
+        let value = kv
+            .value()
+            .ok_or("Internal logic error: Unable to extract value from key/value pair")?;
+        let contained_nonnested_lists = walk_kind(&value, NODE_LIST).filter(|elem| {
+            // As we're walking down the tree looking for list nodes under `kv`, we don't
+            // want to walk too deep. We're looking for lists, but we don't want to find
+            // any lists that are inside other lists, since those are likely not patches
+            // (they're probably arguments to `fetchpatch` like `excludes`)
+
+            // So we'll filter the lists returned by walk_kind (which is doing a full
+            // tree traversal) by counting the number of lists that occur between this
+            // node `elem` and `kv`, and checking for there to be only 1.
+
+            // N.b.: there's a more efficient way to do this, but it wouldn't allow us
+            // to re-use walk_kind and implementing our own tree traversal in rust is not
+            // worth it -- speed is not an issue
+            parents(elem.clone().into_node().unwrap())
+                .take_while(|elem| elem.text_range() != kv.node().text_range())
+                .filter(|elem| elem.kind() == NODE_LIST)
+                .count()
+                == 1
+        });
+        for elem in contained_nonnested_lists {
+            let patch_list = List::cast(elem.into_node().ok_or(
+                "Inernal logic error: Unable to cast element with kind NODE_LIST to into a Node",
+            )?)
+            .ok_or(
+                "Internal logic error: Unable to cast from a node with kind NODE_LIST to a List",
+            )?;
+            report.extend(process_patch_list(patch_list, files, file_id)?);
+        }
     }
 
     Ok(report)
 }
 
 fn process_patch_list(
-    kv: KeyValue,
+    patchlist: List,
     files: &Files<String>,
     file_id: FileId,
 ) -> Result<Report, Box<dyn Error>> {
     let mut report: Report = vec![];
 
-    match kv.value().and_then(List::cast) {
-        Some(value) => {
-            // For each element in the list of patches, look for
-            // a comment directly above the element or, if we don't see
-            // one of those, look for a comment within AST of the element.
-            for item in value.items() {
-                let has_comment_above = find_comment_above(&item).is_some();
-                let has_comment_within = find_comment_within(&item).is_some();
+    // For each element in the list of patches, look for
+    // a comment directly above the element or, if we don't see
+    // one of those, look for a comment within AST of the element.
+    for item in patchlist.items() {
+        let has_comment_above = find_comment_above(&item).is_some();
+        let has_comment_within = find_comment_within(&item).is_some();
 
-                if !(has_comment_above || has_comment_within) {
-                    let start = item.text_range().start().to_usize() as u32;
-
-                    report.push(NixpkgsHammerMessage {
-                        msg: "Please add a comment on the line above, explaining the purpose of this patch.".to_string(),
-                        name: "missing-patch-comment",
-                        locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],
-                        link: true,
-                    });
-                }
-            }
-        }
-        None => {
-            let start = kv.node().text_range().start().to_usize() as u32;
+        if !(has_comment_above || has_comment_within) {
+            let start = item.text_range().start().to_usize() as u32;
 
             report.push(NixpkgsHammerMessage {
-                msg: "`patches` should be a list.".to_string(),
+                msg:
+                    "Please add a comment on the line above, explaining the purpose of this patch."
+                        .to_string(),
                 name: "missing-patch-comment",
                 locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],
                 link: true,
             });
         }
-    };
+    }
 
     Ok(report)
 }

--- a/ast-checks/src/tree_utils.rs
+++ b/ast-checks/src/tree_utils.rs
@@ -39,3 +39,7 @@ pub fn prev_siblings(element: &SyntaxElement) -> impl Iterator<Item = SyntaxElem
         it.prev_sibling_or_token()
     }))
 }
+
+pub fn parents(node: SyntaxNode) -> impl Iterator<Item = SyntaxNode> {
+    std::iter::successors(Some(node), |node| node.parent())
+}

--- a/run-tests.py
+++ b/run-tests.py
@@ -19,10 +19,11 @@ def make_test_variant(rule, variant=None, should_match=True):
                 attr_path
             ],
             stdout=subprocess.PIPE,
+            text=True,
         )
 
         if test_build.returncode != 0:
-            raise Exception('error building the test:' + test_build.stdout.decode('utf-8'))
+            raise Exception('error building the test:' + test_build.stdout)
         else:
             report = json.loads(test_build.stdout)
             matches = any(check['name'] == rule for check in report[attr_path])
@@ -159,6 +160,9 @@ class TestSuite(unittest.TestSuite):
                 'general-comment',
                 'comment-above',
                 'comment-within',
+                'complex-structure1',
+                'ignore-nested-lists1',
+                'ignore-nested-lists2',
             ]
         )
 

--- a/tests/missing-patch-comment/complex-structure1.nix
+++ b/tests/missing-patch-comment/complex-structure1.nix
@@ -1,0 +1,21 @@
+{ stdenv
+, lib
+, unrarSupport
+}:
+
+# From https://github.com/NixOS/nixpkgs/pull/113149
+# https://github.com/jtojnar/nixpkgs-hammering/issues/23
+
+stdenv.mkDerivation {
+  name = "comments-in-complex-structure-1";
+
+  src = ../fixtures/make;
+
+  patches = [
+    # Plugin installation (very insecure) disabled (from Debian)
+    ./disable_plugins.patch
+    # Automatic version update disabled by default (from Debian)
+    ./no_updates_dialog.patch
+  ]
+  ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
+}

--- a/tests/missing-patch-comment/default.nix
+++ b/tests/missing-patch-comment/default.nix
@@ -9,4 +9,9 @@
   general-comment = pkgs.callPackage ./general-comment.nix { };
   comment-above = pkgs.callPackage ./comment-above.nix { };
   comment-within = pkgs.callPackage ./comment-within.nix { };
+  complex-structure1 = pkgs.callPackage ./complex-structure1.nix {
+    unrarSupport = true;
+  };
+  ignore-nested-lists1 = pkgs.callPackage ./ignore-nested-lists1.nix { };
+  ignore-nested-lists2 = pkgs.callPackage ./ignore-nested-lists2.nix { };
 }

--- a/tests/missing-patch-comment/ignore-nested-lists1.nix
+++ b/tests/missing-patch-comment/ignore-nested-lists1.nix
@@ -1,0 +1,17 @@
+{ stdenv
+, fetchpatch
+}:
+
+stdenv.mkDerivation {
+  name = "ignore-nested-lists";
+
+  src = ../fixtures/make;
+
+  patches = [
+    # comment here. no comment is required next to "foo" and "bar"
+    (fetchpatch {
+        url = "...";
+        excludes = ["foo" "bar"];
+    })
+  ];
+}

--- a/tests/missing-patch-comment/ignore-nested-lists2.nix
+++ b/tests/missing-patch-comment/ignore-nested-lists2.nix
@@ -1,0 +1,18 @@
+{ stdenv
+, fetchpatch
+, lib
+}:
+
+stdenv.mkDerivation {
+  name = "ignore-nested-lists2";
+
+  src = ../fixtures/make;
+
+  patches = lib.optionals (true) [
+    # comment here. no comment is required next to "foo" and "bar"
+    (fetchpatch {
+        url = "...";
+        excludes = ["foo" "bar"];
+    })
+  ];
+}


### PR DESCRIPTION
The change here is that within the value associated with the `patches` key, we branch on whether the value is a List. If it is, we look for a comment above every entry. If it's not, we look for any lists contained within it, and look for a comment above every entry in each of these sub-lists.

As far as I can tell, the vast majority of 'patches' entries in nixpkgs are, at an AST level, either:
 - a list (handled well)
 - some function applied to a list (like lib.optional)
 - a binary operator  (like `++`)  acting on nodes that are lists or functions applied to lists

Unlike the code before, I can't think of any false positives that this version will emit. It will, however, fail to emit a warning (false negatives) if the AST doesn't actually use a list node in the file we're linting, like:
```
patches = lib.singleton ./path-to-patch.patch
```
But I don't think this is either particularly common or problematic.