### PR TITLE
Fix evaluation of attrs that dependent on disabled packages

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -110,6 +110,16 @@ class TestSuite(unittest.TestSuite):
         )
 
         yield make_test_rule(
+            'EvalError',
+            [
+                'exception',
+            ],
+            [
+                'no-exception',
+            ],
+        )
+
+        yield make_test_rule(
             'explicit-phases',
             [
                 'configure',

--- a/tests/EvalError/default.nix
+++ b/tests/EvalError/default.nix
@@ -1,0 +1,10 @@
+{ pkgs
+}:
+
+{
+  # positive cases
+  exception = pkgs.callPackage ./exception.nix { };
+
+  # negative cases
+  no-exception = pkgs.callPackage ./no-exception.nix { };
+}

--- a/tests/EvalError/exception.nix
+++ b/tests/EvalError/exception.nix
@@ -1,0 +1,11 @@
+{ stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "exception";
+  version = "0";
+
+  src = ../fixtures/make;
+
+  propagatedBuildInputs = [ (builtins.throw "Throw an exception") ];
+}

--- a/tests/EvalError/no-exception.nix
+++ b/tests/EvalError/no-exception.nix
@@ -1,0 +1,11 @@
+{ stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "no-exception";
+  version = "0";
+
+  src = ../fixtures/make;
+
+  propagatedBuildInputs = [ ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,6 +7,7 @@
   attribute-typo = pkgs.callPackage ./attribute-typo { };
   build-tools-in-build-inputs = pkgs.recurseIntoAttrs (pkgs.callPackage ./build-tools-in-build-inputs { });
   duplicate-check-inputs = pkgs.python3.pkgs.callPackage ./duplicate-check-inputs { };
+  EvalError = pkgs.callPackage ./EvalError { };
   explicit-phases = pkgs.callPackage ./explicit-phases { };
   fixup-phase = pkgs.callPackage ./fixup-phase { };
   license-missing = pkgs.callPackage ./license-missing { };

--- a/tools/nixpkgs-hammer
+++ b/tools/nixpkgs-hammer
@@ -140,8 +140,9 @@ def main(args):
             "{attr}" =
               let
                 result = builtins.tryEval pkgs.{attr} or null;
+                maybeReport = builtins.tryEval (result.value.__nixpkgs-hammering-state.reports or []);
               in
-                if !result.success then
+                if !(result.success && maybeReport.success) then
                   {{
                     report = [ {{
                       name = "EvalError";
@@ -163,7 +164,7 @@ def main(args):
                   }}
                 else
                   {{
-                    report = result.value.__nixpkgs-hammering-state.reports or [];
+                    report = if maybeReport.success then maybeReport.value else [];
                     position = result.value.meta.position;
                   }};
             '''


### PR DESCRIPTION
Before:
```
nix run -f . -c nixpkgs-hammer -f ~/projects/nixpkgs python39Packages.pylint --json
error: --- ThrownError ----------------------------------------------------------------------------------------------------------- nix-instantiate
astroid-2.4.2 not supported for interpreter python3.9
(use '--show-trace' to show detailed location information)
Traceback (most recent call last):
  File "/nix/store/188vld53372z94cgva6bbpgd4hgjl41r-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 294, in <module>
    main(args)
  File "/nix/store/188vld53372z94cgva6bbpgd4hgjl41r-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 222, in main
    overlay_data = nix_eval_json(all_messages_nix, args.show_trace)
  File "/nix/store/188vld53372z94cgva6bbpgd4hgjl41r-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 65, in nix_eval_json
    result = subprocess.check_output(
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix-instantiate', '--strict', '--json', '--eval', '-']' returned non-zero exit status 1.
```

After:
```
nix run -f . -c nixpkgs-hammer -f ~/projects/nixpkgs python39Packages.pylint --json
{"python39Packages.pylint": [{"link": false, "msg": "Cannot evaluate attribute \u2018python39Packages.pylint\u2019 in \u2018/home/mcgibbon/projects/nixpkgs\u2019.", "name": "EvalError", "severity": "warning"}]}
```
