### PR TITLE
attribute-typo: whitelist dontAutoPatchelf

### DIFF
--- a/lib/derivation-attributes-unordered.nix
+++ b/lib/derivation-attributes-unordered.nix
@@ -9,6 +9,7 @@
   "strictDeps"
   "hardeningDisable"
   "hardeningEnable"
+  "dontAutoPatchelf"
 
   # Taken from stdenv.xml
   "depsBuildBuild"


### PR DESCRIPTION
Fixes

```
citrix_workspace:

A likely typo in dontAutoPatchelf argument was found, did you mean dontPatchELF?
Near pkgs/applications/networking/remote/citrix-workspace/generic.nix:195:3:
                                                                                                                                                                                            ────────────────────
|
195 |   dontAutoPatchelf = true;
|   ^
────────────────────
See: https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/attribute-typo.md                                                                                                                                                                                            ```