### PR TITLE
checks: prevent 'no-flags-spaces' from throwing a type error

### DIFF
--- a/overlays/no-flags-spaces.nix
+++ b/overlays/no-flags-spaces.nix
@@ -22,7 +22,7 @@ let
     "distFlags"
   ];
 
-  containsSpace = str: builtins.match ".*[[:space:]].*" str != null;
+  containsSpace = str: builtins.match ".*[[:space:]].*" (builtins.toString str) != null;
 
   checkDerivation = drvArgs: drv:
     (map

--- a/run-tests.py
+++ b/run-tests.py
@@ -208,6 +208,7 @@ class TestSuite(unittest.TestSuite):
             ],
             [
                 'okay',
+                'nonstring',
             ],
         )
 

--- a/tests/no-flags-spaces/default.nix
+++ b/tests/no-flags-spaces/default.nix
@@ -7,4 +7,5 @@
 
   # negative cases
   okay = callPackage ./okay.nix { };
+  nonstring = callPackage ./nonstring.nix { };
 }

--- a/tests/no-flags-spaces/nonstring.nix
+++ b/tests/no-flags-spaces/nonstring.nix
@@ -1,0 +1,10 @@
+{ stdenv
+}:
+
+stdenv.mkDerivation {
+  name = "nonstring";
+
+  src = ../fixtures/make;
+
+  configureFlags = [ "--foo" [ "--bar" ] ];
+}


### PR DESCRIPTION
Fixes #68.

I considered making a bigger modification where I throw a different error message if the types are not as expected, but I think it might be better to do that feature for a wider set of attributes using a dedicated approach.