### PR TITLE
attribute-ordering: fix possible crash

### DIFF
--- a/overlays/attribute-ordering.nix
+++ b/overlays/attribute-ordering.nix
@@ -32,7 +32,12 @@ let
       getAttrPos = attr: (builtins.unsafeGetAttrPos attr drvArgs);
       getAttrLine = attr: (getAttrPos attr).line;
 
-      drvAttrs = builtins.sort (a: b: getAttrLine a < getAttrLine b) (builtins.attrNames drvArgs);
+      drvAttrs = lib.pipe drvArgs [
+        builtins.attrNames
+        # Certain functions like mapAttrs can produce attributes without associated position.
+        (builtins.filter (attr: getAttrPos attr != null))
+        (builtins.sort (a: b: getAttrLine a < getAttrLine b))
+      ];
 
       knownDrvAttrs = builtins.filter (attr: preferredOrdering ? "${attr}") drvAttrs;
 


### PR DESCRIPTION
Fixes the following crash, against nixpkgs edb5000ea3e02c8fe1caba17c6c329066d6d8ae9

```
$ nixpkgs-hammer -f . warsow-engine
[1 built, 0.0 MiB DL]
error: --- TypeError ------------------------------------------------------------------------------------------------------------- nix-instantiate
at: (33:27) in file: /nix/store/0gsly7wzm6pkq7x8q8fzs24npsxmzjd5-nixpkgs-hammer/overlays/attribute-ordering.nix

    32|       getAttrPos = attr: (builtins.unsafeGetAttrPos attr drvArgs);
    33|       getAttrLine = attr: (getAttrPos attr).line; #or 0;
      |                           ^
    34| 

value is null while a set was expected
(use '--show-trace' to show detailed location information)
Traceback (most recent call last):
  File "/nix/store/0gsly7wzm6pkq7x8q8fzs24npsxmzjd5-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 318, in <module>
    main(args)
  File "/nix/store/0gsly7wzm6pkq7x8q8fzs24npsxmzjd5-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 238, in main
    overlay_data = nix_eval_json(all_messages_nix, args.show_trace)
  File "/nix/store/0gsly7wzm6pkq7x8q8fzs24npsxmzjd5-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 70, in nix_eval_json
    result = subprocess.check_output(args, encoding="utf-8", input=expr)
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix-instantiate', '--strict', '--json', '--eval', '-']' returned non-zero exit status 1.
```