### PR TITLE
missing-phase-hooks: be more tolerant of type errors in nixpkgs

### DIFF
--- a/overlays/missing-phase-hooks.nix
+++ b/overlays/missing-phase-hooks.nix
@@ -23,7 +23,12 @@ let
           postMissing = builtins.match ".*runHook post${capitalize phase}.*" drvArgs."${phase}Phase" == null;
         in {
           name = "missing-phase-hooks";
-          cond = drvArgs ? "${phase}Phase" && drvArgs."${phase}Phase" != null && (preMissing || postMissing);
+          cond = (
+            drvArgs ? "${phase}Phase" &&
+            drvArgs."${phase}Phase" != null &&
+            builtins.isString drvArgs."${phase}Phase" &&
+            (preMissing || postMissing)
+          );
           msg = ''
             `${phase}Phase` should probably contain ${lib.optionalString preMissing "`runHook pre${capitalize phase}`"}${lib.optionalString (preMissing && postMissing) " and "}${lib.optionalString postMissing "`runHook post${capitalize phase}`"}.
           '';


### PR DESCRIPTION
There's an obvious type error in this file... https://github.com/NixOS/nixpkgs/blob/20.09/pkgs/development/compilers/dasm/default.nix#L14

```
$ nixpkgs-hammer -f . --json dasm
error: --- TypeError ------------------------------------------------------------------------------------------------------------- nix-instantiate
at: (22:24) in file: /nix/store/a4kmahx6mq7sb5x4hxvwn4wlkad5ybzc-nixpkgs-hammer/overlays/missing-phase-hooks.nix

    21|         let
    22|           preMissing = builtins.match ".*runHook pre${capitalize phase}.*"  drvArgs."${phase}Phase" == null;
      |                        ^
    23|           postMissing = builtins.match ".*runHook post${capitalize phase}.*" drvArgs."${phase}Phase" == null;

value is a Boolean while a string was expected
(use '--show-trace' to show detailed location information)
Traceback (most recent call last):
  File "/nix/store/a4kmahx6mq7sb5x4hxvwn4wlkad5ybzc-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 318, in <module>
    main(args)
  File "/nix/store/a4kmahx6mq7sb5x4hxvwn4wlkad5ybzc-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 238, in main
    overlay_data = nix_eval_json(all_messages_nix, args.show_trace)
  File "/nix/store/a4kmahx6mq7sb5x4hxvwn4wlkad5ybzc-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 70, in nix_eval_json
    result = subprocess.check_output(args, encoding="utf-8", input=expr)
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix-instantiate', '--strict', '--json', '--eval', '-']' returned non-zero exit status 1.
```