### PR TITLE
python-include-tests: fix possible type error

### DIFF
--- a/overlays/python-include-tests.nix
+++ b/overlays/python-include-tests.nix
@@ -15,7 +15,7 @@ let
         let
           hasCheckPhase = drvArgs ? checkPhase;
           hasDoCheckFalse = (drvArgs ? doCheck) && (drvArgs.doCheck == false);
-          hasPytestCheckHook = drvArgs ? checkInputs && lib.any (n: n.name == "pytest-check-hook") drvArgs.checkInputs;
+          hasPytestCheckHook = drvArgs ? checkInputs && lib.any (n: (n.name or "") == "pytest-check-hook") drvArgs.checkInputs;
           hasPythonImportsCheck = drvArgs ? pythonImportsCheck;
 
           hasActiveCheckPhase = (hasCheckPhase || hasPytestCheckHook) && (!hasDoCheckFalse);


### PR DESCRIPTION
Fixes
```
nixpkgs-hammer -f . --json  python39Packages.alot
error: --- TypeError ------------------------------------------------------------------------------------------------------------- nix-instantiate
at: (18:69) in file: /nix/store/mn57a9kgk0yc7y0a4rd8xvfaqj3rfbii-nixpkgs-hammer/overlays/python-include-tests.nix

    17|           hasDoCheckFalse = (drvArgs ? doCheck) && (drvArgs.doCheck == false);
    18|           hasPytestCheckHook = drvArgs ? checkInputs && lib.any (n: n.name == "pytest-check-hook") drvArgs.checkInputs;
      |                                                                     ^
    19|           hasPythonImportsCheck = drvArgs ? pythonImportsCheck;

value is null while a set was expected
(use '--show-trace' to show detailed location information)
Traceback (most recent call last):
  File "/nix/store/mn57a9kgk0yc7y0a4rd8xvfaqj3rfbii-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 318, in <module>
    main(args)
  File "/nix/store/mn57a9kgk0yc7y0a4rd8xvfaqj3rfbii-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 238, in main
    overlay_data = nix_eval_json(all_messages_nix, args.show_trace)
  File "/nix/store/mn57a9kgk0yc7y0a4rd8xvfaqj3rfbii-nixpkgs-hammer/bin/.nixpkgs-hammer-wrapped", line 70, in nix_eval_json
    result = subprocess.check_output(args, encoding="utf-8", input=expr)
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/nix/store/wkw6fsjasr7jbbrlakxxpbiapa8hws42-python3-3.8.7/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix-instantiate', '--strict', '--json', '--eval', '-']' returned non-zero exit status 1.
```