### PR TITLE
attribute-typo: whitelist CPPFLAGS

### DIFF
--- a/lib/derivation-attributes.nix
+++ b/lib/derivation-attributes.nix
@@ -50,6 +50,7 @@
     name = "environment variables";
     values = [
       "CFLAGS"
+      "CPPFLAGS"
       "CXXFLAGS"
       "FONTCONFIG_FILE"
       "NIX_CFLAGS_COMPILE"


### PR DESCRIPTION
```
nixpkgs-hammer python37 --exclude attribute-ordering
When evaluating attribute ‘python37’:
warning: attribute-typo
A likely typo in `CPPFLAGS` argument was found, did you mean `CFLAGS` or `CXXFLAGS`?

Near /home/hotpi/.cache/nixpkgs-review/pr-114530-3/nixpkgs/pkgs/development/interpreters/python/cpython/default.nix:242:3:
    |
242 |   CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
    |   ^
See: https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/attribute-typo.md
```