### PR TITLE
attribute-typo: allow dontNpmInstall

### DIFF
--- a/lib/derivation-attributes.nix
+++ b/lib/derivation-attributes.nix
@@ -80,6 +80,7 @@
       "dontUseNinjaInstall"
       "dontFixup"
       "dontUseNinjaCheck"
+      "dontNpmInstall"
     ];
   }
 


### PR DESCRIPTION
```
joplin:                                                                                                                                                                                     <details>                                                                                                                                                                                                                                                                                                                                                                               warning: attribute-typo                                                                                                                                                                     A likely typo in dontNpmInstall argument was found, did you mean dontInstall?                                                                                                                                                                                                                                                                                                           Near pkgs/development/node-packages/node-env.nix:409:14:                                                                                                                                                                                                                                                                                                                                ────────────────────                                                                                                                                                                            |                                                                                                                                                                                       409 |       inherit dontNpmInstall preRebuild unpackPhase buildPhase;
    |              ^
────────────────────

See: https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/attribute-typo.md
warning: attribute-typo
A likely typo in preRebuild argument was found, did you mean postBuild?

Near pkgs/development/node-packages/node-env.nix:409:14:

────────────────────
    |
409 |       inherit dontNpmInstall preRebuild unpackPhase buildPhase;
    |              ^
────────────────────

See: https://github.com/jtojnar/nixpkgs-hammering/blob/master/explanations/attribute-typo.md
warning: maintainers-missing
Package does not have a maintainer. Consider adding yourself?

Near pkgs/development/node-packages/node-packages.nix:85205:5:
```