### PR TITLE
python-include-tests: fix errors when setuptools-check-hook is used

### DIFF
--- a/overlays/python-include-tests.nix
+++ b/overlays/python-include-tests.nix
@@ -8,12 +8,16 @@ let
       name = "python-include-tests";
       cond =
         let
-          hasCheckPhase = drvArgs ? checkPhase;
-          hasDoCheckFalse = (drvArgs ? doCheck) && (drvArgs.doCheck == false);
-          hasPytestCheckHook = drvArgs ? checkInputs && lib.any (n: (n.name or "") == "pytest-check-hook") drvArgs.checkInputs;
+          isTestHook = name: builtins.elem name [
+            "pytest-check-hook"
+            "setuptools-check-hook"
+          ];
+          hasCheckPhase = drvArgs ? checkPhase || drvArgs ? installCheckPhase;
+          hasDoCheckFalse = (drv ? doInstallCheck) && !drv.doInstallCheck;
+          hasCheckHook = lib.any (n: isTestHook (n.name or "")) drv.nativeBuildInputs;
           hasPythonImportsCheck = drvArgs ? pythonImportsCheck;
 
-          hasActiveCheckPhase = (hasCheckPhase || hasPytestCheckHook) && (!hasDoCheckFalse);
+          hasActiveCheckPhase = (hasCheckPhase || hasCheckHook) && (!hasDoCheckFalse);
         in
           !(hasActiveCheckPhase || hasPythonImportsCheck);
       msg = ''

--- a/tests/python-include-tests/no-tests-no-import-checks.nix
+++ b/tests/python-include-tests/no-tests-no-import-checks.nix
@@ -4,5 +4,7 @@
 buildPythonPackage {
   name = "package";
 
+  format = "pyproject";
+
   src = ../fixtures/make;
 }


### PR DESCRIPTION
no-python-tests also fired when a package uses `setuptools-check-hook`,
which is the default for `format = "setuptools"`.

This change also makes the test more robust. Checks in Python packages
are actuall install checks, however `buildPythonPackage` also accepts
`doCheck`/`checkInputs`, which are then used to set
`doInstallCheck`/`installCheckInputs`. Consequently, it is also valid for
a derivation to use `doInstallCheck`/`installCheckInputs` instead.

To complicate matters, we cannot just check derivation arguments,
since `buildPythonPackage` also sets `doInstallCheck/installCheckInputs`
when the project format is `setuptools`.

This change updates the test to look for check hooks in the
`nativeBuildInputs` of the final derivation. As well as checking
whether install checks are enabled.
