### PR TITLE
build tools: remove yacc

### DIFF
--- a/overlays/build-tools-in-build-inputs.nix
+++ b/overlays/build-tools-in-build-inputs.nix
@@ -100,7 +100,6 @@ let
     "xcodebuild"
     "xmlto"
     "xvfb_run"
-    "yacc"
     "yarn"
     "zip"
   ] ++ lib.optionals (prev.stdenv.isDarwin) [


### PR DESCRIPTION
It's just an alias for bison.