### PR TITLE
missing-patch-comment: tweak language of message

### DIFF
--- a/rust-checks/src/bin/missing-patch-comment.rs
+++ b/rust-checks/src/bin/missing-patch-comment.rs
@@ -84,7 +84,7 @@ fn process_patch_list(
 
             report.push(NixpkgsHammerMessage {
                 msg:
-                    "Please add a comment on the line above, explaining the purpose of this patch."
+                    "Consider add a comment on the line above explaining the purpose of this patch."
                         .to_string(),
                 name: "missing-patch-comment",
                 locations: vec![SourceLocation::from_byte_index(files, file_id, start)?],


### PR DESCRIPTION
My feeling is that the current wording of suggestion, which fires in r-rmcgibbo pretty often, is a little bit too strongly worded, so I tried to lighten the wording a little bit, so that it's more of a suggestion rather than a command.