### PR TITLE
flake: remove dependency on naersk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,26 +16,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1662220400,
-        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
-        "owner": "nmattia",
-        "repo": "naersk",
-        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nmattia",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1665634984,
@@ -55,7 +35,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,17 +7,12 @@
       flake = false;
     };
 
-    naersk = {
-      url = "github:nmattia/naersk";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, flake-compat, naersk, nixpkgs, utils }: {
+  outputs = { self, flake-compat, nixpkgs, utils }: {
     overlays = {
       default =
         final:
@@ -26,11 +21,11 @@
         {
           nixpkgs-hammering =
             let
-              naersk-lib = prev.callPackage naersk {};
-
-              rust-checks = naersk-lib.buildPackage {
-                name = "rust-checks";
-                root = ./rust-checks;
+              rust-checks = prev.rustPlatform.buildRustPackage {
+                pname = "rust-checks";
+                version = (prev.lib.importTOML ./rust-checks/Cargo.toml).package.version;
+                src = ./rust-checks;
+                cargoLock.lockFile = ./rust-checks/Cargo.lock;
               };
 
               # Find all of the binaries installed by rust-checks. Note, if this changes
@@ -68,7 +63,7 @@
     };
   } // utils.lib.eachDefaultSystem (system: let
     pkgs = import nixpkgs { inherit system; };
-  in rec {
+  in {
     packages = rec {
       default = nixpkgs-hammering;
 


### PR DESCRIPTION
`buildRustPackage` now supports vendoring from `Cargo.lock` without a hash