### PR TITLE
fix: qmake4Hook was removed from nixpkgs

### DIFF
--- a/overlays/build-tools-in-build-inputs.nix
+++ b/overlays/build-tools-in-build-inputs.nix
@@ -67,7 +67,6 @@ let
     "patchelf"
     "pkg-config"
     "poetry"
-    "qmake4Hook"
     "qt5.wrapQtAppsHook"
     "ronn"
     "rpcsvc-proto"


### PR DESCRIPTION
This results in identical symptoms to #127, and applying `--do-not-catch-errors` discovered that qmake4Hook removal was the culprit.