### PR TITLE
build-tools-in-build-inputs: Do not crash when package is removed from Nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734435836,
-        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "lastModified": 1739019272,
+        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
         "type": "github"
       },
       "original": {

--- a/overlays/build-tools-in-build-inputs.nix
+++ b/overlays/build-tools-in-build-inputs.nix
@@ -43,7 +43,7 @@ let
     "gnum4"
     "gnumake"
     "gnused"
-    "gnustep.make"
+    "gnustep-make"
     "gogUnpackHook"
     "go-md2man"
     "gtk-doc"

--- a/overlays/build-tools-in-build-inputs.nix
+++ b/overlays/build-tools-in-build-inputs.nix
@@ -109,6 +109,8 @@ let
     in
     if package == null then
       if developmentMode then throw "‘${attrPath}’ does not exist in Nixpkgs." else null
+    else if package.meta.broken or false then
+      if developmentMode then throw "‘${attrPath}’ is broken in Nixpkgs." else null
     else
       {
         name = attrPath;

--- a/run-tests.py
+++ b/run-tests.py
@@ -24,6 +24,7 @@ def make_test_variant(rule, variant=None, should_match=True, prebuild=False):
             ["nixpkgs-hammer", "-f", "./tests", "--json", attr_path],
             stdout=subprocess.PIPE,
             text=True,
+            env={**os.environ, "NIXPKGS_HAMMERING_FATAL_EVAL_ISSUES": "1"},
         )
 
         if test_build.returncode != 0:


### PR DESCRIPTION
Fixes: https://github.com/jtojnar/nixpkgs-hammering/issues/150
