### PR TITLE
ci: Fix tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Nix fails to load the flake using flake-compat otherwise.
+        fetch-depth: 0
 
     - name: Install Nix
       uses: cachix/install-nix-action@v31

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v27
+      uses: cachix/install-nix-action@v31
 
     - name: Run tests
       run: nix shell -c ./run-tests.py

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739019272,
-        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
+        "lastModified": 1741678040,
+        "narHash": "sha256-rmBsz7BBcDwfvDkxnKHmolKceGJrr0nyz5PQYZg0kMk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
+        "rev": "3ee8818da146871cd570b164fc4f438f78479a50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
For some reason, the CI eventually started to fail on `flake-compat` not being able to import the `flake.nix` from the repo.

    error:
       … while evaluating attribute '"attribute-ordering.out-of-order"'
         at «stdin»:31:5:
           30| in {
           31|     "attribute-ordering.out-of-order" =
             |     ^
           32|       let
       … while evaluating a branch condition
         at «stdin»:36:9:
           35|       in
           36|         if !(result.success && maybeReport.success) then
             |         ^
           37|           {
       … in the argument of the not operator
         at «stdin»:36:29:
           35|       in
           36|         if !(result.success && maybeReport.success) then
             |                             ^
           37|           {
       … in the left operand of the AND (&&) operator
         at «stdin»:36:29:
           35|       in
           36|         if !(result.success && maybeReport.success) then
             |                             ^
           37|           {
       … while calling the 'tryEval' builtin
         at «stdin»:33:18:
           32|       let
           33|         result = builtins.tryEval pkgs."attribute-ordering"."out-of-order" or null;
             |                  ^
           34|         maybeReport = builtins.tryEval (result.value.__nixpkgs-hammering-state.reports or []);
       … while evaluating the attribute 'attribute-ordering.out-of-order'
         at /home/runner/work/nixpkgs-hammering/nixpkgs-hammering/tests/default.nix:6:3:
            5| {
            6|   attribute-ordering = pkgs.recurseIntoAttrs (pkgs.callPackage ./attribute-ordering { });
             |   ^
            7|   attribute-typo = pkgs.recurseIntoAttrs (pkgs.callPackage ./attribute-typo { });
       … while calling the 'import' builtin
         at /home/runner/work/nixpkgs-hammering/nixpkgs-hammering/tests/default.nix:2:10:
            1| { overlays ? []
            2| , pkgs ? import (import ../default.nix).inputs.nixpkgs.outPath { inherit overlays; }
             |          ^
            3| }:
       … while realising the context of a path
       … while calling the 'import' builtin
         at /home/runner/work/nixpkgs-hammering/nixpkgs-hammering/tests/default.nix:2:18:
            1| { overlays ? []
            2| , pkgs ? import (import ../default.nix).inputs.nixpkgs.outPath { inherit overlays; }
             |                  ^
            3| }:
       … while evaluating the file '/home/runner/work/nixpkgs-hammering/nixpkgs-hammering/default.nix':
       … while evaluating the attribute 'defaultNix'
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:234:5:
          233|
          234|     defaultNix =
             |     ^
          235|       (builtins.removeAttrs result ["__functor"])
       … in the left operand of the update (//) operator
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:236:7:
          235|       (builtins.removeAttrs result ["__functor"])
          236|       // (if result ? defaultPackage.${system} then { default = result.defaultPackage.${system}; } else {})
             |       ^
          237|       // (if result ? packages.${system}.default then { default = result.packages.${system}.default; } else {});
       … while calling the 'removeAttrs' builtin
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:235:8:
          234|     defaultNix =
          235|       (builtins.removeAttrs result ["__functor"])
             |        ^
          236|       // (if result ? defaultPackage.${system} then { default = result.defaultPackage.${system}; } else {})
       … from call site
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:227:10:
          226|     else if lockFile.version >= 5 && lockFile.version <= 7
          227|     then allNodes.${lockFile.root}
             |          ^
          228|     else throw "lock file '${lockFilePath}' has unsupported version ${toString lockFile.version}";
       … while calling anonymous lambda
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:159:13:
          158|     builtins.mapAttrs
          159|       (key: node:
             |             ^
          160|         let
       … in the condition of the assert statement
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:214:13:
          213|           if node.flake or true then
          214|             assert builtins.isFunction flake.outputs;
             |             ^
          215|             result
       … while calling the 'isFunction' builtin
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:214:20:
          213|           if node.flake or true then
          214|             assert builtins.isFunction flake.outputs;
             |                    ^
          215|             result
       … while calling the 'import' builtin
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:170:19:
          169|
          170|           flake = import (outPath + "/flake.nix");
             |                   ^
          171|
       … while realising the context of path '/nix/store/l6wffswn03nbyr03775ymv0dkync2n37-nixpkgs-hammering/flake.nix'
       error: path '/nix/store/l6wffswn03nbyr03775ymv0dkync2n37-nixpkgs-hammering' is not valid

While this is probably a bug in Nix, it works locally. The difference appears to be caused by GitHub actions making a shallow clone.
